### PR TITLE
Change http to https; Vercel only offers https

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ async function waitForDeployment() {
 
   while (new Date().getTime() < endTime) {
     try {
-      return `http://${await getUrl(sha)}`
+      return `https://${await getUrl(sha)}`
     } catch (e) {
       console.log(`Url unavailable. Attempt ${attempt++}.`)
       await sleep(2)


### PR DESCRIPTION
Http is automatically redirected. However, some services that do not properly support redirects might not work very well in this case.  
https://vercel.com/docs/edge-network/encryption  
https://vercel.com/blog/automatic-ssl-with-vercel-lets-encrypt