### PR TITLE
Add team ID and await build parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 
 Maximum time in seconds to wait for the deployment. Default `120`.
 
+### `team-id`
+
+[Vercel team ID](https://vercel.com/docs/api#api-basics/authentication/accessing-resources-owned-by-a-team) if the deployment is owned by a team
+
 ## Outputs
 
 ### `url`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Wait for the deployment to be built before returning the url.
 
 ### `team-id`
 
-[Vercel team ID](https://vercel.com/docs/api#api-basics/authentication/accessing-resources-owned-by-a-team) if the deployment is owned by a team
+[Vercel team ID](https://vercel.com/docs/api#api-basics/authentication/accessing-resources-owned-by-a-team) if the deployment is owned by a team.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 
 Maximum time in seconds to wait for the deployment. Default `120`.
 
+### `await-build`
+
+Wait for the deployment to be built before returning the url.
+
 ### `team-id`
 
 [Vercel team ID](https://vercel.com/docs/api#api-basics/authentication/accessing-resources-owned-by-a-team) if the deployment is owned by a team
@@ -49,6 +53,7 @@ steps:
     with:
       prod-url: example.now.sh
       token: ${{ secrets.VERCEL_TOKEN }}
+      await-build: true
   - run: npm test
     env:
       ENVIRONMENT_URL: ${{ steps.wait-for-vercel.outputs.url }}

--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,14 @@ inputs:
   token:
     description: Vercel authorization token
     required: true
+  team-id:
+    description: Vercel team ID
   timeout:
     description: The max time to run the action (in seconds)
     required: false
     default: "120"
+  await-build:
+    description: Wait for the deployment to be built
 outputs:
   url:
     description: The fully qualified deployment URL

--- a/index.js
+++ b/index.js
@@ -22,10 +22,9 @@ async function getProdUrl(sha) {
 
   const awaitBuild = core.getInput("await-build")
 
-  if(awaitBuild && data.deployments[0].state !== "READY"){
+  if (awaitBuild && data.deployments[0].state !== "READY") {
     throw Error("Deployment not yet ready")
   }
-
 
   return data.url
 }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,13 @@ async function getProdUrl(sha) {
     throw new Error("Commit sha for prod url didn't match")
   }
 
+  const awaitBuild = core.getInput("await-build")
+
+  if(awaitBuild && data.deployments[0].state !== "READY"){
+    throw Error("Deployment not yet ready")
+  }
+
+
   return data.url
 }
 
@@ -27,6 +34,12 @@ async function getBranchUrl(sha) {
   const teamId = core.getInput("team-id")
   const url = `https://api.vercel.com/v5/now/deployments?${teamId ? `teamId=${teamId}&` : ""}meta-githubCommitSha=${sha}`
   const { data } = await axios.get(url, headers)
+
+  const awaitBuild = core.getInput("await-build")
+
+  if(awaitBuild && data.deployments[0].state !== "READY"){
+    throw Error("Deployment not yet ready")
+  }
 
   // If the deployment isn't in the response, this will throw an error and
   // cause a retry.

--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ async function getProdUrl(sha) {
 }
 
 async function getBranchUrl(sha) {
-  const url = `https://api.vercel.com/v5/now/deployments?meta-githubCommitSha=${sha}`
+  const teamId = core.getInput("team-id")
+  const url = `https://api.vercel.com/v5/now/deployments?${teamId ? `teamId=${teamId}&` : ""}meta-githubCommitSha=${sha}`
   const { data } = await axios.get(url, headers)
 
   // If the deployment isn't in the response, this will throw an error and


### PR DESCRIPTION
- Add `team-id` parameter for deployments owned by a team (see [Accessing Resources Owned by a Team](https://vercel.com/docs/api#api-basics/authentication/accessing-resources-owned-by-a-team)) 
- Add `await-build` parameter to check for the build to be succesfully built (see [Deployment Response Parameters](https://vercel.com/docs/api#endpoints/deployments/list-deployments/response-parameters))